### PR TITLE
Python scheduler to handle reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,4 +171,4 @@ flask_session
 bruv
 instance/
 .DS_Store
-test.py
+test*.py

--- a/jobs/schedule_analytics.py
+++ b/jobs/schedule_analytics.py
@@ -1,0 +1,42 @@
+"""Trigger a reset every day at the same time using the schedule library"""
+import schedule
+import time
+import requests
+import threading
+
+def run_continuously():
+    cease_continuous_run = threading.Event()
+
+    class ScheduleThread(threading.Thread):
+        @classmethod
+        def run(cls):
+            while not cease_continuous_run.is_set():
+                interval = schedule.idle_seconds()
+                if interval is None:
+                    # no more jobs
+                    break
+                elif interval > 0:
+                    # sleep exactly the right amount of time
+                    print(f"Time till Analytics reset: {interval} seconds")
+                    time.sleep(interval)
+                schedule.run_pending()
+
+    continuous_thread = ScheduleThread()
+    continuous_thread.start()
+    return cease_continuous_run
+
+
+def analytics_job():
+    """trigger at set time"""
+    response = requests.get("https://spitfire-interractions.onrender.com/api/analytics")
+    print(response.text)
+
+# at 12:01am everyday
+schedule.every().day.at("00:01").do(analytics_job)
+
+
+stop_run_continuously = run_continuously()
+if __name__ == "__main__":
+    time.sleep(60)
+    # Stop the background thread
+    stop_run_continuously.set()

--- a/openapi/__init__.py
+++ b/openapi/__init__.py
@@ -4,7 +4,8 @@ from flask_cors import CORS
 from flask import Flask, session
 from flask_bcrypt import Bcrypt
 from openapi.config import App_Config
-import os
+from jobs.schedule_analytics import stop_run_continuously
+import time
 
 # Create an instance of Swagger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,4 @@ typing_extensions==4.7.1
 urllib3==2.0.5
 Werkzeug==2.3.7
 yarl==1.9.2
+schedule==1.2.1


### PR DESCRIPTION
## Description
* Using cron job was the initial plan but render has setup something against it
* Python schedule library works-ish
* It is set up as background job under the main server process
* It is set to sleep until when it is to execute, to prevent using server compute resources

## Limitations
* I didn't set up a way to stop it, but it stops when the server stops :)